### PR TITLE
Use context middleware to cache hooks responses

### DIFF
--- a/hashgraph-react-wallets/demo/package-lock.json
+++ b/hashgraph-react-wallets/demo/package-lock.json
@@ -36,7 +36,8 @@
       }
     },
     "..": {
-      "version": "1.0.0",
+      "name": "@buidlerlabs/hashgraph-react-wallets",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@bladelabs/blade-web3.js": "^1.0.5",

--- a/hashgraph-react-wallets/demo/package.json
+++ b/hashgraph-react-wallets/demo/package.json
@@ -12,7 +12,7 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
-    "@buidlerlabs/hashgraph-react-wallets": "^1.0.0",
+    "@buidlerlabs/hashgraph-react-wallets": "^1.0.2",
     "buffer": "^6.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/hashgraph-react-wallets/demo/src/components/TransactionDemo.tsx
+++ b/hashgraph-react-wallets/demo/src/components/TransactionDemo.tsx
@@ -7,7 +7,7 @@ import Button from "./Button";
 const TX_STATUS_RESET_DELAY = 5000;
 
 interface IProps {
-    connector: HWBridgeConnector
+    connector?: HWBridgeConnector
 }
 
 interface IState {
@@ -75,7 +75,7 @@ const TransactionDemo = ({ connector }: IProps) => {
             setState(prevState => ({ ...prevState, loading: true }));
 
             const tx = await new TransferTransaction()
-                .addHbarTransfer(accountId, -state.amount)
+                .addHbarTransfer(accountId || '', -state.amount)
                 .addHbarTransfer(AccountId.fromString(state.recipient), state.amount)
                 .freezeWithSigner(signer)
 

--- a/hashgraph-react-wallets/package-lock.json
+++ b/hashgraph-react-wallets/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@buidlerlabs/hashgraph-react-wallets",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@buidlerlabs/hashgraph-react-wallets",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@bladelabs/blade-web3.js": "^1.0.5",
-        "hashconnect": "^0.2.4"
+        "hashconnect": "^0.2.4",
+        "short-uuid": "^4.2.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.21.5",
@@ -4469,6 +4470,11 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/any-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -10518,6 +10524,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/short-uuid": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-4.2.2.tgz",
+      "integrity": "sha512-IE7hDSGV2U/VZoCsjctKX6l5t5ak2jE0+aeGJi3KtvjIUNuZVmHVYUjNBhmo369FIWGDtaieRaO8A83Lvwfpqw==",
+      "dependencies": {
+        "any-base": "^1.1.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -14936,6 +14954,11 @@
       "requires": {
         "color-convert": "^2.0.1"
       }
+    },
+    "any-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
     },
     "anymatch": {
       "version": "3.1.3",
@@ -19426,6 +19449,15 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true
+    },
+    "short-uuid": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/short-uuid/-/short-uuid-4.2.2.tgz",
+      "integrity": "sha512-IE7hDSGV2U/VZoCsjctKX6l5t5ak2jE0+aeGJi3KtvjIUNuZVmHVYUjNBhmo369FIWGDtaieRaO8A83Lvwfpqw==",
+      "requires": {
+        "any-base": "^1.1.0",
+        "uuid": "^8.3.2"
+      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/hashgraph-react-wallets/package.json
+++ b/hashgraph-react-wallets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buidlerlabs/hashgraph-react-wallets",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A lightweight library that aims to provide an easier way to interact with the hedera network from a UI perspective",
   "keywords": [
     "react",
@@ -73,6 +73,7 @@
   },
   "dependencies": {
     "@bladelabs/blade-web3.js": "^1.0.5",
-    "hashconnect": "^0.2.4"
+    "hashconnect": "^0.2.4",
+    "short-uuid": "^4.2.2"
   }
 }

--- a/hashgraph-react-wallets/src/hWBridge/HWBridgeSession.ts
+++ b/hashgraph-react-wallets/src/hWBridge/HWBridgeSession.ts
@@ -1,7 +1,9 @@
 import { HWBridgeConnectorInstance } from './connectors/types'
 import { HWBridgeSessionProps, HWBridgeSigner } from './types'
+import short from 'short-uuid'
 
 export class HWBridgeSession {
+  readonly #sessionId: string
   readonly #connector: HWBridgeConnectorInstance
   #signer: HWBridgeSigner | null = null
   #onUpdate: (session?: HWBridgeSession | null) => void
@@ -11,6 +13,7 @@ export class HWBridgeSession {
   #autoPaired: boolean = false
 
   constructor({ Connector, onUpdate, network, metadata, debug }: HWBridgeSessionProps) {
+    this.#sessionId = short.generate()
     this.#connector = new Connector({
       network,
       metadata,
@@ -67,6 +70,10 @@ export class HWBridgeSession {
 
   async #checkExtensionPresence(): Promise<boolean> {
     return await this.#connector?.checkExtensionPresence()
+  }
+
+  get sessionId(): string {
+    return this.#sessionId
   }
 
   get extensionReady(): boolean {

--- a/hashgraph-react-wallets/src/hWBridge/connectors/BladeConnector/BladeConnector.ts
+++ b/hashgraph-react-wallets/src/hWBridge/connectors/BladeConnector/BladeConnector.ts
@@ -32,7 +32,7 @@ class BladeWalletConnector implements IConnector {
         )
 
       const pairedAccountIds = await this._bladeConnector.createSession({ network: this._network } as SessionParams)
-      const bladeSigner = this._bladeConnector.getSigner() as BladeWallet;
+      const bladeSigner = this._bladeConnector.getSigner() as BladeWallet
 
       if (this._debug && Array.isArray(pairedAccountIds) && pairedAccountIds.length) {
         console.log('[Blade Connector]: Connected with accounts', pairedAccountIds)
@@ -49,10 +49,8 @@ class BladeWalletConnector implements IConnector {
 
       bladeSigner.getProvider = () => ({
         getTransactionReceipt: (transactionId: string) => {
-          return new TransactionReceiptQuery()
-            .setTransactionId(transactionId)
-            .executeWithSigner(bladeSigner!)
-        }
+          return new TransactionReceiptQuery().setTransactionId(transactionId).executeWithSigner(bladeSigner!)
+        },
       })
 
       return bladeSigner
@@ -166,4 +164,4 @@ class BladeWalletConnector implements IConnector {
   }
 }
 
-export default BladeWalletConnector;
+export default BladeWalletConnector

--- a/hashgraph-react-wallets/src/hWBridge/connectors/HashpackConnector/HashpackConnector.ts
+++ b/hashgraph-react-wallets/src/hWBridge/connectors/HashpackConnector/HashpackConnector.ts
@@ -114,8 +114,10 @@ class HashpackWalletConnector implements IConnector {
       }
       return hcSigner
     } catch (e) {
-      this.wipePairingData();
-      throw new Error("The signer could not be retrieved. It's possible that the cached account doesn't exist. Please attempt to establish a new connection.");
+      this.wipePairingData()
+      throw new Error(
+        "The signer could not be retrieved. It's possible that the cached account doesn't exist. Please attempt to establish a new connection.",
+      )
     }
   }
 
@@ -193,4 +195,4 @@ class HashpackWalletConnector implements IConnector {
   }
 }
 
-export default HashpackWalletConnector;
+export default HashpackWalletConnector

--- a/hashgraph-react-wallets/src/hWBridge/interfaces/index.ts
+++ b/hashgraph-react-wallets/src/hWBridge/interfaces/index.ts
@@ -1,1 +1,1 @@
-export {default as IConnector} from "./IConnector"
+export { default as IConnector } from './IConnector'

--- a/hashgraph-react-wallets/src/hWBridge/types.ts
+++ b/hashgraph-react-wallets/src/hWBridge/types.ts
@@ -25,5 +25,5 @@ export type HWBridgeSessionProps = {
 
 export type HWBridgeInstance = InstanceType<typeof HWBridge>
 
-export * from './interfaces/IConnector';
+export * from './interfaces/IConnector'
 export * from './connectors/types'

--- a/hashgraph-react-wallets/src/hooks/useHWContext.ts
+++ b/hashgraph-react-wallets/src/hooks/useHWContext.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react'
+import { HWContext } from '../provider/HWContextProvider'
+
+export const useHWContext = () => {
+  const context = useContext(HWContext)
+
+  if (!context) {
+    throw new Error('This component must be rendered inside HWBridgeProvider.')
+  }
+
+  return context ?? null
+}

--- a/hashgraph-react-wallets/src/hooks/useWallet.ts
+++ b/hashgraph-react-wallets/src/hooks/useWallet.ts
@@ -2,7 +2,7 @@ import { HWBridgeSession } from '../hWBridge'
 import { HWBridgeConnector } from '../hWBridge/connectors/types'
 import { useHWBridge } from './useHWBridge'
 
-export function useWallet<TConnector extends HWBridgeConnector>(connector?: TConnector): HWBridgeSession {
+export function useWallet<TConnector extends HWBridgeConnector>(connector?: TConnector | null): HWBridgeSession {
   const hWBridge = useHWBridge()
 
   if (!hWBridge) {

--- a/hashgraph-react-wallets/src/provider/HWBridgeProvider.tsx
+++ b/hashgraph-react-wallets/src/provider/HWBridgeProvider.tsx
@@ -9,6 +9,7 @@ import {
   HWBridgeConnector,
 } from '../hWBridge/types'
 import { HWBridgeSession } from '../hWBridge/HWBridgeSession'
+import HWContextProvider from './HWContextProvider'
 
 interface IProps {
   children: ReactNode | ReactNode[]
@@ -57,7 +58,11 @@ const HWBridgeProvider = ({
 
   const value = useMemo(() => context, [context]) || ({} as IHWBridgeContext)
 
-  return <HWBridgeContext.Provider value={value}>{children}</HWBridgeContext.Provider>
+  return (
+    <HWBridgeContext.Provider value={value}>
+      <HWContextProvider>{children}</HWContextProvider>
+    </HWBridgeContext.Provider>
+  )
 }
 
 export default React.memo(HWBridgeProvider)

--- a/hashgraph-react-wallets/src/provider/HWContextProvider.tsx
+++ b/hashgraph-react-wallets/src/provider/HWContextProvider.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react'
+import { ReactNode, createContext, useEffect, useMemo, useState } from 'react'
+import { useConnectedWallets } from '../hooks'
+import { AccountBalance, AccountBalanceJson, AccountId } from '@hashgraph/sdk'
+import { HWBridgeSession } from '../hWBridge'
+
+export interface HWContext {
+  accountIds: { [sessionId: string]: AccountId }
+  balances: { [sessionId: string]: AccountBalance }
+  getAccountId: <TSession extends HWBridgeSession>(wallet: TSession | null) => Promise<AccountId | null>
+  getAccountBalance: <TSession extends HWBridgeSession>(wallet: TSession | null) => Promise<AccountBalanceJson | null>
+}
+
+export const HWContext = createContext<HWContext | null>(null)
+
+const HWContextProvider = ({ children }: { children: ReactNode | ReactNode[] }) => {
+  const wallets = useConnectedWallets()
+  const connectedSessionIDs = wallets.map(({ sessionId }) => sessionId).join(',')
+  const [context, setContext] = useState<HWContext>({
+    accountIds: {},
+    balances: {},
+  } as HWContext)
+
+  const handleGetAccountId = async <TSession extends HWBridgeSession>(
+    wallet: TSession | null,
+  ): Promise<AccountId | null> => {
+    if (!wallet) return null
+
+    if (wallet && wallet.signer) {
+      const accountId = await wallet.signer.getAccountId()
+
+      setContext(
+        (prevContext) =>
+          ({
+            ...prevContext,
+            accountIds: {
+              ...prevContext?.accountIds,
+              [wallet.sessionId]: accountId,
+            },
+          } as HWContext),
+      )
+
+      return accountId
+    }
+
+    return null
+  }
+
+  const handleGetBalance = async <TSession extends HWBridgeSession>(
+    wallet: TSession | null,
+  ): Promise<AccountBalanceJson | null> => {
+    if (!wallet) return null
+
+    if (wallet && wallet.signer) {
+      const accountBalance = await wallet.signer.getAccountBalance()
+
+      const balance = accountBalance instanceof AccountBalance ? accountBalance.toJSON() : accountBalance
+
+      setContext(
+        (prevContext) =>
+          ({
+            ...prevContext,
+            balances: {
+              ...prevContext?.balances,
+              [wallet.sessionId]: balance,
+            },
+          } as HWContext),
+      )
+
+      return balance
+    }
+
+    return null
+  }
+
+  useEffect(() => {
+    ;(async () => {
+      if (!wallets.length) return
+
+      wallets.map(async (wallet) => {
+        const accountId = await handleGetAccountId(wallet)
+        const balance = await handleGetBalance(wallet)
+
+        setContext(
+          (prevContext) =>
+            ({
+              ...prevContext,
+              accountIds: {
+                ...prevContext?.accountIds,
+                [wallet.sessionId]: accountId,
+              },
+              balances: {
+                ...prevContext?.balances,
+                [wallet.sessionId]: balance,
+              },
+            } as HWContext),
+        )
+      })
+    })()
+  }, [connectedSessionIDs])
+
+  const value =
+    useMemo(
+      () => ({
+        ...context,
+        getAccountId: handleGetAccountId,
+        getAccountBalance: handleGetBalance,
+      }),
+      [context],
+    ) || ({} as HWContext)
+
+  return <HWContext.Provider value={value}>{children}</HWContext.Provider>
+}
+
+export default React.memo(HWContextProvider)


### PR DESCRIPTION
**Description**:
This PR modifies the HWBridge context hierarchy by introducing a new context layer in order to cache the `useBalance` and `useAccount` hooks response.

**Related issue(s)**:

Fixes #
Prevent multiple network requests when the hooks are used in various places in the app. 