### PR TITLE
Fix tokens balance response limitation

### DIFF
--- a/hashgraph-react-wallets/package.json
+++ b/hashgraph-react-wallets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buidlerlabs/hashgraph-react-wallets",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A lightweight library that aims to provide an easier way to interact with the hedera network from a UI perspective",
   "keywords": [
     "react",

--- a/hashgraph-react-wallets/src/actions/types.ts
+++ b/hashgraph-react-wallets/src/actions/types.ts
@@ -1,3 +1,7 @@
+export type MirrorResponseStatus = {
+  messages: { message: string }[]
+}
+
 export type MirrorBalancesTokenType = {
   token_id: string
   balance: number
@@ -15,7 +19,20 @@ export type MirrorBalancesResponse = {
     next: string | null
   }
   timestamp: string
-  _status?: {
-    messages: { message: string }[]
+  _status?: MirrorResponseStatus
+}
+
+export type MirrorTokensResponse = {
+  tokens: {
+    automatic_association: boolean
+    balance: number
+    created_timestamp: string
+    freeze_status: string
+    kyc_status: string
+    token_id: string
+  }[]
+  links: {
+    next: string | null
   }
+  _status?: MirrorResponseStatus
 }

--- a/hashgraph-react-wallets/src/hooks/useTokensBalance.ts
+++ b/hashgraph-react-wallets/src/hooks/useTokensBalance.ts
@@ -2,7 +2,7 @@ import { queryMirror } from '../actions'
 import { HWBridgeConnector } from '../hWBridge/connectors/types'
 import { useQuery } from '@tanstack/react-query'
 import { useAccountId } from './useAccountId'
-import { MirrorBalancesResponse } from '../actions/types'
+import { MirrorTokensResponse } from '../actions/types'
 import { HWBridgeQueryKeys } from '../constants'
 import { useWallet } from './useWallet'
 
@@ -25,8 +25,8 @@ export function useTokensBalance<TConnector extends HWBridgeConnector>({
   const enabled = Boolean(connectedAccountId && (autoFetch ?? true))
 
   const queryFn = async () => {
-    return queryMirror<MirrorBalancesResponse[]>({
-      path: `/api/v1/balances?account.id=${connectedAccountId}`,
+    return queryMirror<MirrorTokensResponse[]>({
+      path: `/api/v1/accounts/${connectedAccountId}/tokens`,
       queryKey: [HWBridgeQueryKeys.TOKENS_BALANCE],
       options: {
         network: wallet.connector.network,
@@ -41,8 +41,7 @@ export function useTokensBalance<TConnector extends HWBridgeConnector>({
     select: (data) => {
       if (!data || data[0]._status?.messages.length) return null
 
-      const accountBalances = data.map(({ balances }) => balances).flat()
-      const tokenBalances = accountBalances.map(({ tokens }) => tokens).flat()
+      const tokenBalances = data.map(({ tokens }) => tokens).flat()
 
       if (tokens?.length) {
         return tokenBalances.filter(({ token_id }) => tokens.indexOf(token_id) > -1)


### PR DESCRIPTION
**Description**:

This PR modifies the query for the `useTokensBalance` hook in order to avoid the response limitation for the associated tokens.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)