### PR TITLE
Fix wallet active connection state

### DIFF
--- a/hashgraph-react-wallets/package.json
+++ b/hashgraph-react-wallets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buidlerlabs/hashgraph-react-wallets",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A lightweight library that aims to provide an easier way to interact with the hedera network from a UI perspective",
   "keywords": [
     "react",


### PR DESCRIPTION
**Description**:

This PR fixes the wallet's connection state.
If there's no web3 active connection, continue restoring the session for Hedera native wallets, otherwise, wait until the Wagmi config state is initialized then proceed to restore the connection.
 
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
